### PR TITLE
Expose socket connect method that takes query parameters.

### DIFF
--- a/src/ofxSocketIO.cpp
+++ b/src/ofxSocketIO.cpp
@@ -7,6 +7,11 @@
 #include "ofxSocketIO.h"
 
 void ofxSocketIO::setup (std::string &address) {
+  std::map<std::string,std::string> query;
+  setup(address, query);
+}
+
+void ofxSocketIO::setup (std::string &address, std::map<std::string,std::string> &query) {
   currentStatus = "not connected";
 
   client.set_open_listener(std::bind(&ofxSocketIO::onConnect, this));
@@ -14,7 +19,7 @@ void ofxSocketIO::setup (std::string &address) {
   client.set_fail_listener(std::bind(&ofxSocketIO::onFail, this));
   client.set_reconnect_listener(std::bind(&ofxSocketIO::onTryReconnect, this));
 
-  client.connect(address);
+  client.connect(address, query);
 }
 
 void ofxSocketIO::onConnect () {

--- a/src/ofxSocketIO.h
+++ b/src/ofxSocketIO.h
@@ -30,6 +30,7 @@ private :
 
 public :
   void setup(std::string& address);
+  void setup(std::string& address, std::map<std::string,std::string>& query);
 
   void bindEvent(ofEvent<ofxSocketIOData&>& event, std::string eventName);
 


### PR DESCRIPTION
In order to connect to a socket.io server requiring an authentication
token to be sent, we needed the ability to send a query string when
connecting.

This commit simply exposes the method on the underling sio_client that
takes query parameters in the form of a string/string map.
